### PR TITLE
Fix name 'os' is not defined

### DIFF
--- a/Baseline/evaluate.py
+++ b/Baseline/evaluate.py
@@ -1,6 +1,7 @@
 import sys
 import getopt
 import errno
+import os
 from pathlib import Path
 
 # Total number of files in chosen datasets


### PR DESCRIPTION
Fix the error:

```python
Traceback (most recent call last):
  File "Baseline/evaluate.py", line 151, in <module>
    main()
  File "Baseline/evaluate.py", line 136, in main
    raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), path_to_task)
NameError: name 'os' is not defined
```